### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/ac-update.yml
+++ b/.github/workflows/ac-update.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4.1.4
         with:
           token: ${{ secrets.GIT_TOKEN }}
       - name: Run GitHub Actions Version Updater

--- a/.github/workflows/build-kernel-a13.yml
+++ b/.github/workflows/build-kernel-a13.yml
@@ -94,9 +94,9 @@ jobs:
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.7
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.4
         with:
           path: KernelSU
           fetch-depth: 0
@@ -124,7 +124,7 @@ jobs:
 
       - name: Bot session cache
         id: bot_session_cache
-        uses: actions/cache@v4
+        uses: actions/cache@v4.0.2
         if: false
         with:
           path: scripts/ksubot.session
@@ -147,7 +147,7 @@ jobs:
         run: ls -R
 
       - name: Upload images artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.3.3
         with:
           name: boot-images-android13
           path: Image-android13*/*.img.gz

--- a/.github/workflows/build-kernel-a14.yml
+++ b/.github/workflows/build-kernel-a14.yml
@@ -73,9 +73,9 @@ jobs:
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.7
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.4
         with:
           path: KernelSU
           fetch-depth: 0
@@ -103,7 +103,7 @@ jobs:
 
       - name: Bot session cache
         id: bot_session_cache
-        uses: actions/cache@v4
+        uses: actions/cache@v4.0.2
         if: false
         with:
           path: scripts/ksubot.session
@@ -126,7 +126,7 @@ jobs:
         run: ls -R
 
       - name: Upload images artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.3.3
         with:
           name: boot-images-android14
           path: Image-android14*/*.img.gz

--- a/.github/workflows/build-kernel-arcvm.yml
+++ b/.github/workflows/build-kernel-arcvm.yml
@@ -66,7 +66,7 @@ jobs:
           sudo ln -s --force /usr/bin/clang++-$LLVM_VERSION /usr/bin/clang++
 
       - name: Checkout KernelSU
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.4
         with:
           path: KernelSU
           fetch-depth: 0
@@ -129,7 +129,7 @@ jobs:
           echo "file_path=${PWD}/arch/${ARCH}/boot/${KERNEL_IMAGE_NAME}" >> $GITHUB_ENV
 
       - name: Upload kernel-ARCVM-${{ matrix.arch }}-${{ env.version }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.3.3
         with:
           name: kernel-ARCVM-${{ matrix.arch }}-${{ env.version }}
           path: "${{ env.file_path }}"

--- a/.github/workflows/build-manager.yml
+++ b/.github/workflows/build-manager.yml
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.4
         with:
           fetch-depth: 0
 
@@ -79,24 +79,24 @@ jobs:
           fi
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v4.2.1
         with:
           distribution: temurin
           java-version: 21
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v3.3.1
         with:
           gradle-home-cache-cleanup: true
 
       - name: Download arm64 ksud
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.7
         with:
           name: ksud-aarch64-linux-android
           path: .
 
       - name: Download x86_64 ksud
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.7
         with:
           name: ksud-x86_64-linux-android
           path: .
@@ -120,14 +120,14 @@ jobs:
           ./gradlew clean assembleRelease
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.3.3
         if: ${{ ( github.event_name != 'pull_request' && github.ref == 'refs/heads/main' ) || github.ref_type == 'tag' }}
         with:
           name: manager
           path: manager/app/build/outputs/apk/release/*.apk
 
       - name: Upload mappings
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.3.3
         if: ${{ ( github.event_name != 'pull_request' && github.ref == 'refs/heads/main' ) || github.ref_type == 'tag' }}
         with:
           name: "mappings"
@@ -136,7 +136,7 @@ jobs:
       - name: Bot session cache
         if: github.event_name != 'pull_request' && steps.need_upload.outputs.UPLOAD == 'true'
         id: bot_session_cache
-        uses: actions/cache@v4
+        uses: actions/cache@v4.0.2
         with:
           path: scripts/ksubot.session
           key: ${{ runner.os }}-bot-session

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -21,9 +21,9 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.4
       - run: rustup update --force-non-host stable-x86_64-unknown-linux-gnu
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@v2.7.3
         with:
           workspaces: userspace/ksud
 

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -31,11 +31,11 @@ jobs:
         working-directory: ./website
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.4
         with:
           fetch-depth: 0 # Not needed if lastUpdated is not enabled
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v4.0.2
         with:
           node-version: 20
           cache: yarn # or pnpm / yarn
@@ -49,7 +49,7 @@ jobs:
           yarn docs:build
           touch docs/.vitepress/dist/.nojekyll
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v3.0.1
         with:
           path: website/docs/.vitepress/dist
 
@@ -64,4 +64,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v4.0.5

--- a/.github/workflows/ksud-releases.yml
+++ b/.github/workflows/ksud-releases.yml
@@ -63,7 +63,7 @@ jobs:
           TIME=$(date +"%Y%m%d")
           echo "TIME=$TIME" >> $GITHUB_ENV
       - name: Download Artifact
-        uses: actions/download-artifact@v4.1.4
+        uses: actions/download-artifact@v4.1.7
         with:
             name: ksud-${{ matrix.target }}
       - name: Package (${{ matrix.target }})

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -21,13 +21,13 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.4
 
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@v1
         with:
           components: rustfmt
 
-      - uses: LoliGothick/rustfmt-check@master
+      - uses: LoliGothick/rustfmt-check@v0.4.2
         with:
           token: ${{ github.token }}
           working-directory: userspace/ksud


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.3.3](https://github.com/actions/upload-artifact/releases/tag/v4.3.3)** on 2024-04-22T16:21:25Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.4](https://github.com/actions/checkout/releases/tag/v4.1.4)** on 2024-04-24T13:33:24Z
* **[LoliGothick/rustfmt-check](https://github.com/LoliGothick/rustfmt-check)** published a new release **[v0.4.2](https://github.com/loliGothicK/rustfmt-check/releases/tag/v0.4.2)** on 2024-02-12T15:54:59Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v4.2.1](https://github.com/actions/setup-java/releases/tag/v4.2.1)** on 2024-03-14T14:29:47Z
* **[actions/upload-pages-artifact](https://github.com/actions/upload-pages-artifact)** published a new release **[v3.0.1](https://github.com/actions/upload-pages-artifact/releases/tag/v3.0.1)** on 2024-02-07T06:59:16Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.0.2](https://github.com/actions/setup-node/releases/tag/v4.0.2)** on 2024-02-07T04:51:19Z
* **[Swatinem/rust-cache](https://github.com/Swatinem/rust-cache)** published a new release **[v2.7.3](https://github.com/Swatinem/rust-cache/releases/tag/v2.7.3)** on 2024-01-14T08:32:29Z
* **[dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain)** published a new release **[v1](https://github.com/dtolnay/rust-toolchain/releases/tag/v1)** on 2022-07-15T18:16:27Z
* **[actions/download-artifact](https://github.com/actions/download-artifact)** published a new release **[v4.1.7](https://github.com/actions/download-artifact/releases/tag/v4.1.7)** on 2024-04-24T14:48:32Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.0.2](https://github.com/actions/cache/releases/tag/v4.0.2)** on 2024-03-19T15:55:41Z
* **[gradle/actions](https://github.com/gradle/actions)** published a new release **[v3.3.1](https://github.com/gradle/actions/releases/tag/v3.3.1)** on 2024-04-18T19:49:17Z
* **[actions/deploy-pages](https://github.com/actions/deploy-pages)** published a new release **[v4.0.5](https://github.com/actions/deploy-pages/releases/tag/v4.0.5)** on 2024-03-18T15:43:13Z
