### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-kernel-a12.yml
+++ b/.github/workflows/build-kernel-a12.yml
@@ -53,9 +53,9 @@ jobs:
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.7
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.4
         with:
           path: KernelSU
           fetch-depth: 0
@@ -83,7 +83,7 @@ jobs:
 
       - name: Bot session cache
         id: bot_session_cache
-        uses: actions/cache@v4
+        uses: actions/cache@v4.0.2
         if: false
         with:
           path: scripts/ksubot.session
@@ -106,7 +106,7 @@ jobs:
         run: ls -R
 
       - name: Upload images artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.3.3
         with:
           name: boot-images-android12
           path: Image-android12*/*.img.gz

--- a/.github/workflows/build-manager.yml
+++ b/.github/workflows/build-manager.yml
@@ -85,7 +85,7 @@ jobs:
           java-version: 21
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3.3.1
+        uses: gradle/actions/setup-gradle@v3.3.2
         with:
           gradle-home-cache-cleanup: true
 

--- a/.github/workflows/build-su.yml
+++ b/.github/workflows/build-su.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build userspace su
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.1.4
       with:
         fetch-depth: 0
     - name: Setup need_upload
@@ -26,14 +26,14 @@ jobs:
         else
           echo "UPLOAD=false" >> $GITHUB_OUTPUT
         fi
-    - uses: nttld/setup-ndk@v1
+    - uses: nttld/setup-ndk@v1.4.2
       with:
         ndk-version: r26d
     - name: Build su
       working-directory: ./userspace/su
       run: ndk-build
     - name: Upload a Build Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.3.3
       with:
         name: su
         path: ./userspace/su/libs

--- a/.github/workflows/ksud-releases.yml
+++ b/.github/workflows/ksud-releases.yml
@@ -90,7 +90,7 @@ jobs:
        target: ${{ matrix.target }}-unknown-linux-musl
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.4
         with:
           repository: 'vc-teahouse/ksud-amd64-debian-base'
           ref: ${{ matrix.target }}
@@ -103,7 +103,7 @@ jobs:
           TIME=$(date +"%Y%m%d")
           echo "TIME=$TIME" >> $GITHUB_ENV
       - name: Download Artifact
-        uses: actions/download-artifact@v4.1.4
+        uses: actions/download-artifact@v4.1.7
         with:
             name: ksud-${{ env.target }}
       - name: copy
@@ -124,7 +124,7 @@ jobs:
         run: |
           sudo alien -r --scripts ksud-${{ env.target }}.deb
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.3
         with:
           name: ksud-${{ env.target }}-packed
           path: ./ksud-*.*

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -18,7 +18,7 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.4
 
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@2.0.0


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.0.2](https://github.com/actions/cache/releases/tag/v4.0.2)** on 2024-03-19T15:55:41Z
* **[gradle/actions](https://github.com/gradle/actions)** published a new release **[v3.3.2](https://github.com/gradle/actions/releases/tag/v3.3.2)** on 2024-04-25T20:46:22Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.3.3](https://github.com/actions/upload-artifact/releases/tag/v4.3.3)** on 2024-04-22T16:21:25Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.4](https://github.com/actions/checkout/releases/tag/v4.1.4)** on 2024-04-24T13:33:24Z
* **[nttld/setup-ndk](https://github.com/nttld/setup-ndk)** published a new release **[v1.4.2](https://github.com/nttld/setup-ndk/releases/tag/v1.4.2)** on 2023-11-22T08:02:10Z
* **[actions/download-artifact](https://github.com/actions/download-artifact)** published a new release **[v4.1.7](https://github.com/actions/download-artifact/releases/tag/v4.1.7)** on 2024-04-24T14:48:32Z
