### PR TITLE
Kernel(Kconfig): fix if expression on certain linux version

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -33,7 +33,7 @@ config KSU_CMDLINE
 
 config KSU_COMPAT_GKI
         bool "KernelSU Compat for GKI kernels"
-        default y if LINUX_VERSION_CODE >= KERNEL_VERSION(5,1,0)
+        default y if LINUX_VERSION_CODE >= 328704
         default n
 
 config KSU_MANUAL_HOOK

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -35,8 +35,6 @@ config KSU_COMPAT_GKI
         bool "KernelSU Compat for GKI kernels"
         default y if LINUX_VERSION_CODE >= KERNEL_VERSION(5,1,0)
         default n
-        help
-          Enable KernelSU compatibility for GKI (Generic Kernel Image) kernels.
 
 config KSU_MANUAL_HOOK
 	bool "Manual hooking GKI kernels without kprobes"

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -32,9 +32,11 @@ config KSU_CMDLINE
 	  Value 1 means enabled, value 0 means disabled.
 
 config KSU_COMPAT_GKI
-	bool "KernelSU Compat for GKI kernels"
-	default y if $(VERSION) >= 5 && $(PATCHLEVEL) >= 1
-	default n
+        bool "KernelSU Compat for GKI kernels"
+        default y if LINUX_VERSION_CODE >= KERNEL_VERSION(5,1,0)
+        default n
+        help
+          Enable KernelSU compatibility for GKI (Generic Kernel Image) kernels.
 
 config KSU_MANUAL_HOOK
 	bool "Manual hooking GKI kernels without kprobes"


### PR DESCRIPTION
This fix was generated by DeepSeek.

Fix:
```log
make[1]: Entering directory '/home/runner/work/Kernel-Builder/Kernel-Builder/MIUI_phoenix_ztc1997/out'
  GEN     ./Makefile
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  SHIPPED scripts/kconfig/zconf.tab.c
  SHIPPED scripts/kconfig/zconf.lex.c
  HOSTCC  scripts/kconfig/zconf.tab.o
  HOSTLD  scripts/kconfig/conf
drivers/kernelsu/Kconfig:36:warning: ignoring unsupported character '$'
drivers/kernelsu/Kconfig:37: syntax error
drivers/kernelsu/Kconfig:36:warning: ignoring unsupported character '$'
drivers/kernelsu/Kconfig:36: invalid option
make[2]: *** [/home/runner/work/Kernel-Builder/Kernel-Builder/MIUI_phoenix_ztc1997/MIUI/scripts/kconfig/Makefile:113: vendor/phoenix_ztc1997_defconfig] Error 1
make[1]: *** [/home/runner/work/Kernel-Builder/Kernel-Builder/MIUI_phoenix_ztc1997/MIUI/Makefile:554: vendor/phoenix_ztc1997_defconfig] Error 2
make[1]: Leaving directory '/home/runner/work/Kernel-Builder/Kernel-Builder/MIUI_phoenix_ztc1997/out'
make: *** [Makefile:148: sub-make] Error 2
```